### PR TITLE
aws-encryption-sdk 3.1.1 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,20 +6,22 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/aws-encryption-sdk-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 8d5fbf018fc68d6b1cacbe4dd037fd805296c7736a9fe457eb684d053f7f9563
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - boto3 >=1.10.0
     - cryptography >=2.5.0
     - attrs >=17.4.0
@@ -28,15 +30,21 @@ requirements:
 test:
   imports:
     - aws_encryption_sdk
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/aws/aws-encryption-sdk-python
+  dev_url: https://github.com/aws/aws-encryption-sdk-python
+  doc_url: https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/introduction.html
   summary: AWS Encryption SDK implementation for Python
+  description: |
+    The AWS Encryption SDK is a client-side encryption library designed to make it easy for everyone to encrypt and decrypt data using industry standards and best practices. 
+    It enables you to focus on the core functionality of your application, rather than on how to best encrypt and decrypt your data. 
   license: Apache-2.0
+  license_family: APACHE
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
Changelog: https://github.com/aws/aws-encryption-sdk-python/blob/v3.1.1/CHANGELOG.rst
License: https://github.com/aws/aws-encryption-sdk-python/blob/v3.1.1/LICENSE
Requirements: 
- https://github.com/aws/aws-encryption-sdk-python/blob/v3.1.1/requirements.txt
- https://github.com/aws/aws-encryption-sdk-python/blob/v3.1.1/setup.py

Actions:
1. Apply an initial **percy** [patch](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/test_patch.json) and run locally a [script](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/updater_standalone.py) to: 
  - Remove `noarch python`
  - Skip `py<36`
  - Add flags `--no-deps --no-build-isolation` to `script`
  - Add missing `setuptools` & `wheel` to `host`
  - Fix `python` in `host` and `run`
2. Add `dev_url` and `doc_url`
3. Add `description`
4. Add `license_family`